### PR TITLE
Refactor role_in and role_rin to improve performance

### DIFF
--- a/commands/roles/role_in.js
+++ b/commands/roles/role_in.js
@@ -1,5 +1,5 @@
 const { Command } = require("discord.js-commando");
-const DiscordUtil = require('../../common/discordutil.js');
+const Discord = require('discord.js');
 
 module.exports = class RemoveRoleCommand extends Command {
   constructor(client) {
@@ -25,18 +25,23 @@ module.exports = class RemoveRoleCommand extends Command {
     });
   }
 
-  async run(message, { baseRoleID, assignedRoleID}) {    
-    var members = message.guild.members.cache;
+  async run(message, { baseRoleID, assignedRoleID }) {
     baseRoleID = baseRoleID.replace(/\D/g, "");
     assignedRoleID = assignedRoleID.replace(/\D/g, "");
-    var usersWithRole = []
-    members.forEach(member => {
-      if(member.roles.cache.has(baseRoleID)){
-        member.roles.add([assignedRoleID]);
-        usersWithRole.push(member);
-      }
-    })
-    const attachment = new Discord.MessageAttachment(Buffer.from(`${usersWithRole.join("\n")}`, 'utf-8'), 'usersID.txt');
+    const members = message.guild.members.cache.filter(member => member.roles.cache.has(baseRoleID));
+
+    try {
+      members.forEach(member => {
+        member.roles.add([assignedRoleID])
+      });
+    } catch (error) {
+      console.error(error)
+    }
+
+    // members is a collection, needs to be converted to Array
+    // usersWithRoles = [[id, <@id>]], we want to return the id with tags (<@id>)
+    const usersWithRoles = Array.from(members, item => item[1]).join('\n');
+    const attachment = new Discord.MessageAttachment(Buffer.from(usersWithRoles, 'utf-8'), 'usersID.txt');
     message.channel.send(`Users with role ${baseRoleID} added role ${assignedRoleID}`, attachment);
   }
 };

--- a/commands/roles/role_rin.js
+++ b/commands/roles/role_rin.js
@@ -25,19 +25,23 @@ module.exports = class RemoveRoleCommand extends Command {
     });
   }
 
-  async run(message, { baseRoleID, assignedRoleID}) {    
-    var members = message.guild.members.cache;
+  async run(message, { baseRoleID, assignedRoleID }) {
     baseRoleID = baseRoleID.replace(/\D/g, "");
     assignedRoleID = assignedRoleID.replace(/\D/g, "");
-    console.log(baseRoleID);
-    var usersWithRole = []
-    members.forEach(member => {
-      if(member.roles.cache.has(baseRoleID)){
-        member.roles.remove([assignedRoleID]);
-        usersWithRole.push(member);
-      }
-    })
-    const attachment = new Discord.MessageAttachment(Buffer.from(`${usersWithRole.join("\n")}`, 'utf-8'), 'usersID.txt');
+    const members = message.guild.members.cache.filter(member => member.roles.cache.has(baseRoleID));
+
+    try {
+      members.forEach(member => {
+        member.roles.remove([assignedRoleID])
+      });
+    } catch (error) {
+      console.error(error)
+    }
+
+    // members is a collection, needs to be converted to Array
+    // usersWithRoles = [[id, <@id>]], we want to return the id with tags (<@id>)
+    const usersWithRolesRemoved = Array.from(members, item => item[1]).join('\n');
+    const attachment = new Discord.MessageAttachment(Buffer.from(usersWithRolesRemoved, 'utf-8'), 'usersID.txt');
     message.channel.send(`Users with role ${baseRoleID} removed role ${assignedRoleID}`, attachment);
   }
 };


### PR DESCRIPTION
I did some tests with adding/removing roles for 11 users. 
`role_in`: 1-2 ms improvement
`role_rin`: 2-3 ms improvement

Changes
- Filter members to only those with the baseRole
- Add try/catch for the add/remove operations
- Removed pushing member to new array. If try/catch passes then we know all the filtered members succeeded in adding the new role